### PR TITLE
Reduced volume of blips and explosions as they were a bit much.

### DIFF
--- a/addons/ridiculous_coding/blip.tscn
+++ b/addons/ridiculous_coding/blip.tscn
@@ -117,6 +117,7 @@ __meta__ = {
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 1 )
+volume_db = -12.0
 autoplay = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/addons/ridiculous_coding/boom.tscn
+++ b/addons/ridiculous_coding/boom.tscn
@@ -82,7 +82,7 @@ __meta__ = {
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 2 )
-volume_db = -6.0
+volume_db = -26.0
 autoplay = true
 
 [node name="Timer" type="Timer" parent="."]


### PR DESCRIPTION
The explosions were WAY too loud to be used for any kind of extended period of time, and the blips were pretty loud, too.  Reduced the volume of both.  Put this in a separate pull request in case you just wanted to take one of my tweaks.