### PR TITLE
Godot4 texture filter fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Godot-specific ignores
 .godot/*
 .import
-*.import
 export.cfg
 export_presets.cfg
 

--- a/addons/ridiculous_coding/blip.tscn
+++ b/addons/ridiculous_coding/blip.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=19 format=3 uid="uid://cuhdlb32q67t2"]
+[gd_scene load_steps=19 format=3 uid="uid://c0fhho0dp1svt"]
 
 [ext_resource type="Script" path="res://addons/ridiculous_coding/blip.gd" id="1_tp8nq"]
 [ext_resource type="Texture2D" uid="uid://d1tio2ceqgm7m" path="res://addons/ridiculous_coding/blip.png" id="2_kj7um"]
 [ext_resource type="AudioStream" uid="uid://b2ood3lkcgpqb" path="res://addons/ridiculous_coding/blip.wav" id="3_xg6qd"]
-[ext_resource type="FontFile" uid="uid://lp5ov7pqea1q" path="res://addons/ridiculous_coding/font.tres" id="4_ullf3"]
+[ext_resource type="FontFile" uid="uid://bvwnnnja1ur2i" path="res://addons/ridiculous_coding/font.tres" id="4_ullf3"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_hp4ed"]
 atlas = ExtResource("2_kj7um")
@@ -39,7 +39,31 @@ region = Rect2(224, 0, 32, 32)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_g4ki7"]
 animations = [{
-"frames": [SubResource("AtlasTexture_hp4ed"), SubResource("AtlasTexture_hcxxe"), SubResource("AtlasTexture_3w7u8"), SubResource("AtlasTexture_qo2pv"), SubResource("AtlasTexture_55mlh"), SubResource("AtlasTexture_3eube"), SubResource("AtlasTexture_jwwsh"), SubResource("AtlasTexture_ye4cv")],
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hp4ed")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hcxxe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3w7u8")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_qo2pv")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_55mlh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3eube")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jwwsh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ye4cv")
+}],
 "loop": false,
 "name": &"default",
 "speed": 24.0
@@ -102,12 +126,14 @@ gravity = Vector3(0, 0, 0)
 color_ramp = SubResource("GradientTexture2D_gu7qo")
 
 [node name="Node2D" type="Node2D"]
+texture_filter = 1
 script = ExtResource("1_tp8nq")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 scale = Vector2(5, 5)
-frames = SubResource("SpriteFrames_g4ki7")
-playing = true
+sprite_frames = SubResource("SpriteFrames_g4ki7")
+frame = 7
+frame_progress = 1.0
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3_xg6qd")
@@ -115,24 +141,25 @@ volume_db = -12.0
 autoplay = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "default"
 libraries = {
 "": SubResource("AnimationLibrary_8epm6")
 }
+autoplay = "default"
 
 [node name="GPUParticles2D" type="GPUParticles2D" parent="."]
 emitting = false
 amount = 50
+process_material = SubResource("ParticleProcessMaterial_5k50n")
 lifetime = 0.5
 one_shot = true
 explosiveness = 1.0
-process_material = SubResource("ParticleProcessMaterial_5k50n")
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
 
 [node name="Label" type="Label" parent="."]
-modulate = Color(1.59163, 1.00259, 1.09438, 1)
+modulate = Color(1.88557, 1.35563, 0.609976, 1)
+texture_filter = 1
 offset_left = -35.0
 offset_top = -70.0
 offset_right = 35.0

--- a/addons/ridiculous_coding/boom.tscn
+++ b/addons/ridiculous_coding/boom.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=15 format=3 uid="uid://b1mpg7xsrglhk"]
+[gd_scene load_steps=15 format=3 uid="uid://c4rdv4wkukc5g"]
 
 [ext_resource type="Texture2D" uid="uid://dl75e74oom1i3" path="res://addons/ridiculous_coding/boom.png" id="1"]
 [ext_resource type="AudioStream" uid="uid://b6841f7osi4rh" path="res://addons/ridiculous_coding/boom.wav" id="2"]
 [ext_resource type="Script" path="res://addons/ridiculous_coding/boom.gd" id="4"]
-[ext_resource type="FontFile" uid="uid://lp5ov7pqea1q" path="res://addons/ridiculous_coding/font.tres" id="5"]
+[ext_resource type="FontFile" uid="uid://bvwnnnja1ur2i" path="res://addons/ridiculous_coding/font.tres" id="5"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g3t5t"]
 atlas = ExtResource("1")
@@ -35,7 +35,28 @@ region = Rect2(0, 128, 128, 128)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_ld5tu"]
 animations = [{
-"frames": [SubResource("AtlasTexture_g3t5t"), SubResource("AtlasTexture_4skxo"), SubResource("AtlasTexture_ccvbr"), SubResource("AtlasTexture_0ojec"), SubResource("AtlasTexture_1koxs"), SubResource("AtlasTexture_g5t7n"), SubResource("AtlasTexture_27xno")],
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_g3t5t")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4skxo")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ccvbr")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0ojec")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1koxs")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_g5t7n")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_27xno")
+}],
 "loop": false,
 "name": &"default",
 "speed": 24.0
@@ -74,12 +95,14 @@ _data = {
 }
 
 [node name="Node2D" type="Node2D"]
+texture_filter = 1
 script = ExtResource("4")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 scale = Vector2(0.5, 0.5)
-frames = SubResource("SpriteFrames_ld5tu")
-playing = true
+sprite_frames = SubResource("SpriteFrames_ld5tu")
+frame = 6
+frame_progress = 1.0
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2")
@@ -90,7 +113,8 @@ autoplay = true
 one_shot = true
 
 [node name="Label" type="Label" parent="."]
-modulate = Color(0.463204, 1.95831, 1.49541, 1)
+modulate = Color(0.852828, 1.64201, 1.90577, 1)
+texture_filter = 1
 offset_left = -35.0
 offset_top = -70.0
 offset_right = 35.0
@@ -98,13 +122,14 @@ offset_bottom = -47.0
 scale = Vector2(2, 2)
 pivot_offset = Vector2(35, 8)
 theme_override_fonts/font = ExtResource("5")
+theme_override_font_sizes/font_size = 16
 uppercase = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "default"
 libraries = {
 "": SubResource("AnimationLibrary_ocb2c")
 }
+autoplay = "default"
 
 [connection signal="animation_finished" from="AnimatedSprite2D" to="." method="_on_AnimatedSprite_animation_finished"]
 [connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]

--- a/addons/ridiculous_coding/dock.tscn
+++ b/addons/ridiculous_coding/dock.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=8 format=3 uid="uid://b76vnt4rv4p0q"]
 
 [ext_resource type="Script" path="res://addons/ridiculous_coding/dock.gd" id="1_bwupq"]
-[ext_resource type="Texture2D" uid="uid://dgda8elabipl5" path="res://addons/ridiculous_coding/under.png" id="3_vdb3k"]
-[ext_resource type="AudioStream" uid="uid://dyi5lstxrfkdt" path="res://addons/ridiculous_coding/fireworks.wav" id="4_1o4lv"]
-[ext_resource type="Texture2D" uid="uid://dqpxh1bccjaae" path="res://addons/ridiculous_coding/progress.png" id="4_y2kl4"]
+[ext_resource type="Texture2D" uid="uid://c3ltnrdrb2qmg" path="res://addons/ridiculous_coding/under.png" id="3_vdb3k"]
+[ext_resource type="AudioStream" uid="uid://g6lh6kjt0ynq" path="res://addons/ridiculous_coding/fireworks.wav" id="4_1o4lv"]
+[ext_resource type="Texture2D" uid="uid://dmvuvaqf5uhwi" path="res://addons/ridiculous_coding/progress.png" id="4_y2kl4"]
 
 [sub_resource type="Gradient" id="Gradient_v1eyn"]
 offsets = PackedFloat32Array(0, 0.419689, 0.715026, 1)

--- a/addons/ridiculous_coding/font.tres
+++ b/addons/ridiculous_coding/font.tres
@@ -1,12 +1,9 @@
-[gd_resource type="FontFile" load_steps=2 format=3 uid="uid://lp5ov7pqea1q"]
+[gd_resource type="FontFile" load_steps=2 format=3 uid="uid://bvwnnnja1ur2i"]
 
 [ext_resource type="FontFile" uid="uid://coiaqb8xwuaic" path="res://addons/ridiculous_coding/GravityBold8.ttf" id="1"]
 
 [resource]
-fallbacks = [ExtResource("1")]
-face_index = null
-embolden = null
-transform = null
+fallbacks = Array[Font]([ExtResource("1")])
 cache/0/16/0/ascent = 0.0
 cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
@@ -15,6 +12,7 @@ cache/0/16/0/scale = 1.0
 cache/0/16/0/kerning_overrides/16/0 = Vector2(0, 0)
 cache/0/16/0/kerning_overrides/50/0 = Vector2(0, 0)
 cache/0/16/0/kerning_overrides/28/0 = Vector2(0, 0)
+cache/0/16/0/kerning_overrides/14/0 = Vector2(0, 0)
 cache/0/50/0/ascent = 0.0
 cache/0/50/0/descent = 0.0
 cache/0/50/0/underline_position = 0.0
@@ -23,6 +21,7 @@ cache/0/50/0/scale = 1.0
 cache/0/50/0/kerning_overrides/16/0 = Vector2(0, 0)
 cache/0/50/0/kerning_overrides/50/0 = Vector2(0, 0)
 cache/0/50/0/kerning_overrides/28/0 = Vector2(0, 0)
+cache/0/50/0/kerning_overrides/14/0 = Vector2(0, 0)
 cache/0/28/0/ascent = 0.0
 cache/0/28/0/descent = 0.0
 cache/0/28/0/underline_position = 0.0
@@ -31,3 +30,13 @@ cache/0/28/0/scale = 1.0
 cache/0/28/0/kerning_overrides/16/0 = Vector2(0, 0)
 cache/0/28/0/kerning_overrides/50/0 = Vector2(0, 0)
 cache/0/28/0/kerning_overrides/28/0 = Vector2(0, 0)
+cache/0/28/0/kerning_overrides/14/0 = Vector2(0, 0)
+cache/0/14/0/ascent = 0.0
+cache/0/14/0/descent = 0.0
+cache/0/14/0/underline_position = 0.0
+cache/0/14/0/underline_thickness = 0.0
+cache/0/14/0/scale = 1.0
+cache/0/14/0/kerning_overrides/16/0 = Vector2(0, 0)
+cache/0/14/0/kerning_overrides/50/0 = Vector2(0, 0)
+cache/0/14/0/kerning_overrides/28/0 = Vector2(0, 0)
+cache/0/14/0/kerning_overrides/14/0 = Vector2(0, 0)

--- a/addons/ridiculous_coding/newline.tscn
+++ b/addons/ridiculous_coding/newline.tscn
@@ -1,66 +1,89 @@
-[gd_scene load_steps=10 format=3]
+[gd_scene load_steps=11 format=3 uid="uid://wd4tkg0uxd18"]
 
 [ext_resource type="Script" path="res://addons/ridiculous_coding/newline.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://b1vn1823wqae2" path="res://addons/ridiculous_coding/newline.png" id="2"]
 
-[sub_resource type="AtlasTexture" id=1]
-atlas = ExtResource( 2 )
-region = Rect2( 0, 0, 64, 64 )
+[sub_resource type="AtlasTexture" id="1"]
+atlas = ExtResource("2")
+region = Rect2(0, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id=2]
-atlas = ExtResource( 2 )
-region = Rect2( 64, 0, 64, 64 )
+[sub_resource type="AtlasTexture" id="2"]
+atlas = ExtResource("2")
+region = Rect2(64, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id=3]
-atlas = ExtResource( 2 )
-region = Rect2( 128, 0, 64, 64 )
+[sub_resource type="AtlasTexture" id="3"]
+atlas = ExtResource("2")
+region = Rect2(128, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id=4]
-atlas = ExtResource( 2 )
-region = Rect2( 192, 0, 64, 64 )
+[sub_resource type="AtlasTexture" id="4"]
+atlas = ExtResource("2")
+region = Rect2(192, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id=5]
-atlas = ExtResource( 2 )
-region = Rect2( 256, 0, 64, 64 )
+[sub_resource type="AtlasTexture" id="5"]
+atlas = ExtResource("2")
+region = Rect2(256, 0, 64, 64)
 
-[sub_resource type="SpriteFrames" id=6]
-animations = [ {
-"frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 5 ) ],
+[sub_resource type="SpriteFrames" id="6"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("1")
+}, {
+"duration": 1.0,
+"texture": SubResource("2")
+}, {
+"duration": 1.0,
+"texture": SubResource("3")
+}, {
+"duration": 1.0,
+"texture": SubResource("4")
+}, {
+"duration": 1.0,
+"texture": SubResource("5")
+}],
 "loop": true,
-"name": "default",
+"name": &"default",
 "speed": 12.0
-} ]
+}]
 
-[sub_resource type="Animation" id=7]
+[sub_resource type="Animation" id="7"]
 resource_name = "default"
 tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("AnimatedSprite2D:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"times": PackedFloat32Array( 0, 0.1 ),
-"transitions": PackedFloat32Array( 0.233258, 1 ),
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(0.233258, 1),
 "update": 0,
-"values": [ Vector2( -200, 0 ), Vector2( -50, 0 ) ]
+"values": [Vector2(-200, 0), Vector2(-50, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_gwr1r"]
+_data = {
+"default": SubResource("7")
 }
 
 [node name="Node2D" type="Node2D"]
-script = ExtResource( 1 )
+texture_filter = 1
+script = ExtResource("1")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2( -200, 0 )
+position = Vector2(-50, 0)
 rotation = -1.57079
-scale = Vector2( 2, 2 )
-frames = SubResource( 6 )
-frame = 2
-playing = true
+scale = Vector2(2, 2)
+sprite_frames = SubResource("6")
+frame_progress = 0.432846
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_gwr1r")
+}
 autoplay = "default"
-anims/default = SubResource( 7 )
+
 [connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]


### PR DESCRIPTION
The text and FX look blurry in Godot 4, so I fixed that by disabling filter on the textures and labels in the various scenes and set the proper font size and also removed *.import from the .gitignore so import settings get preserved.